### PR TITLE
Get mp3 tags from Spotify Web API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ Debug/
 Release/
 .vs/
 
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+
 # Windows shortcuts
 *.lnk
 

--- a/EspionSpotify/App.config
+++ b/EspionSpotify/App.config
@@ -46,6 +46,12 @@
             <setting name="DisableAds" serializeAs="String">
                 <value>False</value>
             </setting>
+          <setting name="SpotifyClientId" serializeAs="String">
+            <value></value>
+          </setting>
+          <setting name="SpotifySecret" serializeAs="String">
+            <value></value>
+          </setting>
         </EspionSpotify.Properties.Settings>
     </userSettings>
   <runtime>

--- a/EspionSpotify/Mp3TagsInfo.cs
+++ b/EspionSpotify/Mp3TagsInfo.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Xml;
+using SpotifyAPI.Web;
+using SpotifyAPI.Web.Auth;
+using SpotifyAPI.Web.Enums;
+using SpotifyAPI.Web.Models;
 using TagLib;
 using File = System.IO.File;
 
@@ -13,10 +19,21 @@ namespace EspionSpotify
         public int Compteur { get; set; }
         public bool BCdTrack { get; set; }
         public Song Song { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+
 
         private readonly string[] _apiKey = { "c117eb33c9d44d34734dfdcafa7a162d", "01a049d30c4e17c1586707acf5d0fb17", "82eb5ead8c6ece5c162b461615495b18" };
 
         public void SetTagLibDataToMp3()
+        {
+            if (!SetTagLibDataToMp3WithSpotiry())
+            {
+                SetTagLibDataToMp3WithAudioScrobbler();
+            }
+        }
+
+        private void SetTagLibDataToMp3WithAudioScrobbler()
         {
             var mp3 = TagLib.File.Create(CurrentFile);
 
@@ -118,6 +135,91 @@ namespace EspionSpotify
             if (File.Exists(CurrentFile)) mp3.Save();
 
             mp3.Dispose();
+        }
+
+        internal bool SetTagLibDataToMp3WithSpotiry()
+        {
+            if (string.IsNullOrEmpty(ClientId) || string.IsNullOrEmpty(ClientSecret)) return false;
+
+            using (var mp3 = TagLib.File.Create(CurrentFile))
+            {
+                var tag = mp3.Tag;
+                var webApi = CreateSpotifyWebApi();
+
+                if (!string.IsNullOrEmpty(Song.TrackId))
+                {
+                    var track = GetFullTrack(webApi);
+
+                    if (track == null) return false;
+
+                    // track settings
+                    tag.Title = track.Name;
+                    tag.Track = (uint) track.TrackNumber;
+                    tag.Performers = track.Artists.Select(a => a.Name).ToArray();
+                    tag.Disc = (uint) track.DiscNumber;
+                    tag.Comment = track.Uri;
+
+                    // album settings - optional
+                    var album = GetFullAlbum(webApi, track.Album.Id);
+                    if (album != null)
+                    {
+                        tag.AlbumArtists = album.Artists.Select(a => a.Name).ToArray();
+                        tag.Album = album.Name;
+                        tag.Genres = album.Genres.ToArray();
+                        if (uint.TryParse(album.ReleaseDate?.Substring(0, 4), out var year))
+                        {
+                            tag.Year = year;
+                        }
+
+                        if (album.Images.Count > 0)
+                        {
+                            var pictures = new List<IPicture>();
+                            foreach (var albumImage in album.Images)
+                            {
+                                pictures.Add(GetAlbumCover(albumImage.Url));
+                            }
+
+                            tag.Pictures = pictures.ToArray();
+                        }
+                    }
+
+                    if (File.Exists(CurrentFile)) mp3.Save();
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private FullTrack GetFullTrack(SpotifyWebAPI spotifyWebApi)
+        {
+            var track = spotifyWebApi.GetTrack(Song.TrackId);
+            return track.HasError() ? null : track;
+        }
+
+        private FullAlbum GetFullAlbum(SpotifyWebAPI spotifyWebApi, string albumId)
+        {
+            var album = spotifyWebApi.GetAlbum(albumId);
+            return album.HasError() ? null : album;
+        }
+
+        private SpotifyWebAPI CreateSpotifyWebApi()
+        {
+            var auth = new ClientCredentialsAuth()
+            {
+                ClientId = ClientId,
+                ClientSecret = ClientSecret,
+                Scope = Scope.None,
+            };
+            //With this token object, we now can make calls
+            var token = auth.DoAuth();
+            return new SpotifyWebAPI()
+            {
+                TokenType = token.TokenType,
+                AccessToken = token.AccessToken,
+                UseAuth = true
+            };
         }
 
         private static Picture GetAlbumCover(string link)

--- a/EspionSpotify/Properties/Settings.Designer.cs
+++ b/EspionSpotify/Properties/Settings.Designer.cs
@@ -166,5 +166,35 @@ namespace EspionSpotify.Properties {
                 this["DisableAds"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"")]
+        public string SpotifyClientId
+        {
+            get
+            {
+                return ((string)(this["SpotifyClientId"]));
+            }
+            set
+            {
+                this["SpotifyClientId"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"")]
+        public string SpotifySecret
+        {
+            get
+            {
+                return ((string)(this["SpotifySecret"]));
+            }
+            set
+            {
+                this["SpotifySecret"] = value;
+            }
+        }
     }
 }

--- a/EspionSpotify/Recorder.cs
+++ b/EspionSpotify/Recorder.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
+using EspionSpotify.Properties;
 using NAudio.Lame;
 using NAudio.Wave;
 using File = System.IO.File;
@@ -106,7 +107,9 @@ namespace EspionSpotify
                     Song = _song,
                     BCdTrack = _bCdTrack,
                     Compteur = _compteur,
-                    CurrentFile = _currentFile
+                    CurrentFile = _currentFile,
+                    ClientId = Settings.Default.SpotifyClientId,
+                    ClientSecret = Settings.Default.SpotifySecret
                 };
                 mp3TagsInfo.SetTagLibDataToMp3();
 

--- a/EspionSpotify/Song.cs
+++ b/EspionSpotify/Song.cs
@@ -21,6 +21,8 @@ namespace EspionSpotify
         public readonly byte[] ArtLarge;
         public readonly byte[] ArtExtraLarge;
 
+        public readonly string TrackId;
+
         public Song()
         {
             Album = null;
@@ -33,6 +35,8 @@ namespace EspionSpotify
 
         public Song(Track track)
         {
+            TrackId = track?.TrackResource?.Uri?.Replace("spotify:track:", string.Empty);
+
             Album = track?.AlbumResource?.Name;
             Artist = track?.ArtistResource?.Name;
             Title = track?.TrackResource?.Name;


### PR DESCRIPTION
Hi,

I implemented some logic to take the track and album information directly from the Spotify Web API.

You/each user that would like to use that logic would need to create some "testing" Spotify application in https://beta.developer.spotify.com/dashboard/ and get the client ID + secret and put that into the app.config (as SpotifyClientId and SpotifySecret).

Then it will take the data from Spotify including track number and album images etc.

Feel free to integrate/use it if you find this helpful.

Best