### PR TITLE
Removed Audio Session from User settings

### DIFF
--- a/EspionSpotify/EspionSpotify.csproj
+++ b/EspionSpotify/EspionSpotify.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/EspionSpotify/Models/UserSettings.cs
+++ b/EspionSpotify/Models/UserSettings.cs
@@ -7,7 +7,6 @@ namespace EspionSpotify.Models
 {
     public class UserSettings
     {
-        private IMainAudioSession _audioSession;
         public string OutputPath { get; set; }
         public LAMEPreset Bitrate { get; set; }
         public MediaFormat MediaFormat { get; set; }
@@ -32,13 +31,6 @@ namespace EspionSpotify.Models
             {
                 return Convert.ToInt32(OrderNumberMask.Replace('0', '9').ToString());
             }
-        }
-
-        public IMainAudioSession AudioSession { get => _audioSession; }
-
-        public void SetAudioSession(ref IMainAudioSession audioSession)
-        {
-            _audioSession = audioSession;
         }
 
         public bool HasRecordingTimerEnabled

--- a/EspionSpotify/Recorder.cs
+++ b/EspionSpotify/Recorder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
+using EspionSpotify.AudioSessions;
 using EspionSpotify.Enums;
 using EspionSpotify.Extensions;
 using EspionSpotify.Models;
@@ -22,6 +23,7 @@ namespace EspionSpotify
         private readonly UserSettings _userSettings;
         private readonly Track _track;
         private readonly IFrmEspionSpotify _form;
+        private readonly IMainAudioSession _audioSession;
         private OutputFile _currentOutputFile;
         private WasapiLoopbackCapture _waveIn;
         private Stream _fileWriter;
@@ -30,11 +32,12 @@ namespace EspionSpotify
         private readonly FileManager _fileManager;
         private readonly IFileSystem _fileSystem;
 
-        public Recorder() { }
+        public Recorder() {}
 
-        public Recorder(IFrmEspionSpotify form, UserSettings userSettings, Track track, IFileSystem fileSystem)
+        public Recorder(IFrmEspionSpotify form, IMainAudioSession audioSession, UserSettings userSettings, Track track, IFileSystem fileSystem)
         {
             _form = form;
+            _audioSession = audioSession;
             _fileSystem = fileSystem;
             _track = track;
             _userSettings = userSettings;
@@ -51,7 +54,7 @@ namespace EspionSpotify
             _currentOutputFile = _fileManager.GetOutputFile();
             _tempFile = _fileManager.GetTempFile();
 
-            _waveIn = new WasapiLoopbackCapture(_userSettings.AudioSession.AudioMMDevicesManager.AudioEndPointDevice);
+            _waveIn = new WasapiLoopbackCapture(_audioSession.AudioMMDevicesManager.AudioEndPointDevice);
             _waveIn.DataAvailable += WaveIn_DataAvailable;
             _waveIn.RecordingStopped += WaveIn_RecordingStopped;
 
@@ -180,9 +183,9 @@ namespace EspionSpotify
             }
         }
 
-        public static bool TestFileWriter(IFrmEspionSpotify form, UserSettings settings)
+        public static bool TestFileWriter(IFrmEspionSpotify form, IMainAudioSession audioSession, UserSettings settings)
         {
-            var waveIn = new WasapiLoopbackCapture(settings.AudioSession.AudioMMDevicesManager.AudioEndPointDevice);
+            var waveIn = new WasapiLoopbackCapture(audioSession.AudioMMDevicesManager.AudioEndPointDevice);
             switch (settings.MediaFormat)
             {
                 case MediaFormat.Mp3:

--- a/EspionSpotify/frmEspionSpotify.cs
+++ b/EspionSpotify/frmEspionSpotify.cs
@@ -44,7 +44,6 @@ namespace EspionSpotify
             _audioSession = new MainAudioSession(Settings.Default.AudioEndPointDeviceID);
 
             _userSettings = new UserSettings();
-            _userSettings.SetAudioSession(ref _audioSession);
 
             if (string.IsNullOrEmpty(Settings.Default.Directory))
             {
@@ -396,7 +395,7 @@ namespace EspionSpotify
 
         private async void StartRecording()
         {
-            _watcher = new Watcher(this, _userSettings);
+            _watcher = new Watcher(this, _audioSession, _userSettings);
 
             await Task.Run(_watcher.Run);
 


### PR DESCRIPTION
- audio session is a wasapi instance and should be kept in user settings
- doing this make user settings clonable