### PR TITLE
Fixed 1st recording: spotify event listener start sooner

### DIFF
--- a/EspionSpotify/Spotify/ISpotifyHandler.cs
+++ b/EspionSpotify/Spotify/ISpotifyHandler.cs
@@ -21,6 +21,7 @@ namespace EspionSpotify.Spotify
         event EventHandler<TrackTimeChangeEventArgs> OnTrackTimeChange;
 
         Task<Track> GetTrack();
+        Task TriggerEvent();
 
         void Dispose();
     }

--- a/EspionSpotify/Spotify/SpotifyHandler.cs
+++ b/EspionSpotify/Spotify/SpotifyHandler.cs
@@ -67,6 +67,11 @@ namespace EspionSpotify.Spotify
 
         public async void ElapsedEventTick(object sender, ElapsedEventArgs e)
         {
+            await TriggerEvent();
+        }
+
+        public async Task TriggerEvent()
+        { 
             SpotifyLatestStatus = await SpotifyProcess.GetSpotifyStatus();
             if (SpotifyLatestStatus?.CurrentTrack == null)
             {

--- a/EspionSpotify/Watcher.cs
+++ b/EspionSpotify/Watcher.cs
@@ -166,10 +166,8 @@ namespace EspionSpotify
 
         private void BindSpotifyEventHandlers()
         {
-            Spotify = new SpotifyHandler(_audioSession)
-            {
-                ListenForEvents = true
-            };
+            Spotify = new SpotifyHandler(_audioSession);
+
             Spotify.OnPlayStateChange += OnPlayStateChanged;
             Spotify.OnTrackChange += OnTrackChanged;
             Spotify.OnTrackTimeChange += OnTrackTimeChanged;
@@ -263,20 +261,17 @@ namespace EspionSpotify
 
         private async void InitializeRecordingSession()
         {
-            if (!ExternalAPI.Instance.IsAuthenticated && Spotify.SpotifyLatestStatus == null)
-            {
-                await ExternalAPI.Instance.Authenticate();
-            }
-
             _audioSession.SetSpotifyVolumeToHighAndOthersToMute(MUTE);
 
             var track = await Spotify.GetTrack();
+
             if (track == null) return;
 
             _isPlaying = track.Playing;
             _form.UpdateIconSpotify(_isPlaying);
 
-            _currentTrack = track;
+            Spotify.Track = new Track();
+            Spotify.ListenForEvents = true;
 
             _form.UpdatePlayingTitle(_currentTrack.ToString());
             MutesSpotifyAds(_currentTrack.Ad);


### PR DESCRIPTION
it may have a delay if no audio session is detected for spotify