### PR TITLE
297 log error that lastfm api could not be resolved instead of crashing

### DIFF
--- a/EspionSpotify/Enums/TranslationKeys.cs
+++ b/EspionSpotify/Enums/TranslationKeys.cs
@@ -35,6 +35,7 @@
         lblSpy,
         logAd,
         logDeleting,
+        logException,
         logMaxFileSequenceReached,
         logMissingDlls,
         logPreviousLogs,

--- a/EspionSpotify/Translations/I18nKeys.cs
+++ b/EspionSpotify/Translations/I18nKeys.cs
@@ -39,6 +39,7 @@ namespace EspionSpotify.Models
 
         public static TranslationKeys LogAd { get => TranslationKeys.logAd; }
         public static TranslationKeys LogDeleting { get => TranslationKeys.logDeleting; }
+        public static TranslationKeys LogException { get => TranslationKeys.logException; }
         public static TranslationKeys LogMaxFileSequenceReached { get => TranslationKeys.logMaxFileSequenceReached; }
         public static TranslationKeys LogMissingDlls { get => TranslationKeys.logMissingDlls; }
         public static TranslationKeys LogPreviousLogs { get => TranslationKeys.logPreviousLogs; }

--- a/EspionSpotify/Translations/de.Designer.cs
+++ b/EspionSpotify/Translations/de.Designer.cs
@@ -358,6 +358,15 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // Fehler: {0}.
+        /// </summary>
+        internal static string logException {
+            get {
+                return ResourceManager.GetString("logException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to // Zähler: Maximales Dateisequenzpräfix von {0} erreicht.
         /// </summary>
         internal static string logMaxFileSequenceReached {

--- a/EspionSpotify/Translations/de.resx
+++ b/EspionSpotify/Translations/de.resx
@@ -445,4 +445,8 @@
     <value>Spotify API Dashboard</value>
     <comment>interface**</comment>
   </data>
+  <data name="logException" xml:space="preserve">
+    <value>// Fehler: {0}</value>
+    <comment>console</comment>
+  </data>
 </root>

--- a/EspionSpotify/Translations/en.Designer.cs
+++ b/EspionSpotify/Translations/en.Designer.cs
@@ -358,6 +358,15 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // Error: {0}.
+        /// </summary>
+        internal static string logException {
+            get {
+                return ResourceManager.GetString("logException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to // Counter: Max file sequence prefix of {0} reached.
         /// </summary>
         internal static string logMaxFileSequenceReached {

--- a/EspionSpotify/Translations/en.resx
+++ b/EspionSpotify/Translations/en.resx
@@ -445,4 +445,8 @@
     <value>Spotify API Dashboard</value>
     <comment>interface**</comment>
   </data>
+  <data name="logException" xml:space="preserve">
+    <value>// Error: {0}</value>
+    <comment>console</comment>
+  </data>
 </root>

--- a/EspionSpotify/Translations/fr.Designer.cs
+++ b/EspionSpotify/Translations/fr.Designer.cs
@@ -358,6 +358,15 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // Erreur: {0}.
+        /// </summary>
+        internal static string logException {
+            get {
+                return ResourceManager.GetString("logException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to // Compteur: Max de la séquence de préfix de fichier de {0} atteint.
         /// </summary>
         internal static string logMaxFileSequenceReached {

--- a/EspionSpotify/Translations/fr.resx
+++ b/EspionSpotify/Translations/fr.resx
@@ -445,4 +445,8 @@
     <value>Tableau de bord de Spotify API</value>
     <comment>interface**</comment>
   </data>
+  <data name="logException" xml:space="preserve">
+    <value>// Erreur: {0}</value>
+    <comment>console</comment>
+  </data>
 </root>

--- a/EspionSpotify/Translations/nl.Designer.cs
+++ b/EspionSpotify/Translations/nl.Designer.cs
@@ -358,6 +358,15 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // Fout: {0}.
+        /// </summary>
+        internal static string logException {
+            get {
+                return ResourceManager.GetString("logException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to // Teller: Max. Voorvoegsel voor bestandsreeks van {0} bereikt.
         /// </summary>
         internal static string logMaxFileSequenceReached {

--- a/EspionSpotify/Translations/nl.resx
+++ b/EspionSpotify/Translations/nl.resx
@@ -445,4 +445,8 @@
     <value>Spotify API-dashboard</value>
     <comment>interface**</comment>
   </data>
+  <data name="logException" xml:space="preserve">
+    <value>// Fout: {0}</value>
+    <comment>console</comment>
+  </data>
 </root>

--- a/EspionSpotify/frmEspionSpotify.cs
+++ b/EspionSpotify/frmEspionSpotify.cs
@@ -32,10 +32,10 @@ namespace EspionSpotify
         private FrmSpotifyAPICredentials _frmSpotifyApiCredentials;
 
         private readonly TranslationKeys[] _recorderStatusTranslationKeys = new[] {
-                TranslationKeys.logRecording,
-                TranslationKeys.logRecorded,
-                TranslationKeys.logDeleting,
-                TranslationKeys.logTrackExists,
+                I18nKeys.LogRecording,
+                I18nKeys.LogRecorded,
+                I18nKeys.LogDeleting,
+                I18nKeys.LogTrackExists,
             };
 
         public ResourceManager Rm { get; private set; }
@@ -406,7 +406,7 @@ namespace EspionSpotify
                 // set message type
                 rtbLog.AppendText(type);
                 rtbLog.Select(rtbLog.TextLength - type.Length, type.Length + 1);
-                rtbLog.SelectionColor = resource.Equals(TranslationKeys.logRecording)
+                rtbLog.SelectionColor = resource.Equals(I18nKeys.LogRecording)
                     ? rtbLog.SelectionColor.SpotifyPrimaryText()
                     : rtbLog.SelectionColor.SpotifySecondaryText();
                 rtbLog.SelectionFont = GetDefaultSelectionFont(FontStyle.Bold);
@@ -414,7 +414,7 @@ namespace EspionSpotify
                 // set message msg
                 rtbLog.AppendText(msg + Environment.NewLine);
                 rtbLog.Select(rtbLog.TextLength - msg.Length, msg.Length);
-                rtbLog.SelectionColor = rtbLog.SelectionColor = resource.Equals(TranslationKeys.logDeleting)
+                rtbLog.SelectionColor = rtbLog.SelectionColor = resource.Equals(I18nKeys.LogDeleting)
                     ? rtbLog.SelectionColor.SpotifySecondaryTextAlternate()
                     : rtbLog.SelectionColor.SpotifySecondaryText();
                 rtbLog.SelectionFont = GetDefaultSelectionFont(FontStyle.Regular);


### PR DESCRIPTION
user will have to check his proxy to make sure lastfm domain `ws.audioscrobbler.com` is whitelisted to be able to use it for media tags.

close #297