### PR TITLE
Reverted used of prevent sleep mode with AWAYMODE_REQUIRED since it triggers anti virus

### DIFF
--- a/EspionSpotify/Native/NativeMethods.cs
+++ b/EspionSpotify/Native/NativeMethods.cs
@@ -7,7 +7,7 @@ namespace EspionSpotify.Native
     {
         public static void PreventSleep()
         {
-            SetThreadExecutionState(ExecutionState.EsContinuous | ExecutionState.EsAwaymodeRequired | ExecutionState.EsSystemRequired);
+            SetThreadExecutionState(ExecutionState.EsContinuous | ExecutionState.EsSystemRequired);
         }
 
         public static void AllowSleep()


### PR DESCRIPTION
windows defender false positive on Trojan Win32/Wacatac.G!ml 
https://malwarefixes.com/threats/trojanwin32-wacatac-dml/

related to #278