### PR TITLE
Fix failure to save podcasts to files

### DIFF
--- a/EspionSpotify/Models/Track.cs
+++ b/EspionSpotify/Models/Track.cs
@@ -106,7 +106,7 @@ namespace EspionSpotify.Models
         public byte[] ArtMedium { get; set; }
         public byte[] ArtSmall { get; set; }
 
-        private bool IsNormal =>
+        public bool IsNormal =>
             !string.IsNullOrEmpty(Artist)
             && !string.IsNullOrEmpty(Title)
             && !Ad;

--- a/EspionSpotify/Recorder.cs
+++ b/EspionSpotify/Recorder.cs
@@ -182,7 +182,7 @@ namespace EspionSpotify
         
         private async Task RecordingStopped()
         {
-            while (_track.MetaDataUpdated == null) await Task.Delay(100);
+            while (_track.MetaDataUpdated == null && _track.IsNormal) await Task.Delay(100);
             var skipped = !_canBeSkippedValidated && await StopRecordingIfTrackCanBeSkipped();
             if (_tempWaveWriter == null || skipped)
             {


### PR DESCRIPTION
Tracks that are not normal (podcasts) will never escape the Task.Delay loop in RecordingStopped as MetaDataUpdated will never be set in GetTrack. Abnormal tracks will now escape the while loop.

It's still necessary to record ads and save duplicate recordings to get podcasts to save.

[Issue 457](https://github.com/jwallet/spy-spotify/issues/457)