### PR TITLE
LastFM: Fetch album cover if various artists & use cover 300px or lower

### DIFF
--- a/EspionSpotify.Tests/LastFMAPITests.cs
+++ b/EspionSpotify.Tests/LastFMAPITests.cs
@@ -16,7 +16,7 @@ namespace EspionSpotify.Tests
         public LastFMAPITests()
         {
             _lastFMAPI = new LastFMAPI();
-            _track = new Track {Artist = "Artist", Title = "Title"};
+            _track = new Track {Artist = "Artist", Title = "Title", TitleExtended = "with DJ", TitleExtendedSeparatorType = TitleSeparatorType.Parenthesis};
         }
 
         [Fact]
@@ -95,7 +95,6 @@ namespace EspionSpotify.Tests
                     Position = "5",
                     Image = new List<Image>
                     {
-                        new Image {Size = AlbumCoverSize.extralarge.ToString(), Url = "http://xlarge-cover-url.local"},
                         new Image {Size = AlbumCoverSize.large.ToString(), Url = "http://large-cover-url.local"},
                         new Image {Size = AlbumCoverSize.medium.ToString(), Url = "http://medium-cover-url.local"},
                         new Image {Size = AlbumCoverSize.small.ToString(), Url = "http://small-cover-url.local"}
@@ -119,12 +118,38 @@ namespace EspionSpotify.Tests
             Assert.NotEqual(trackExtra.Artist.Name, _track.Artist);
             Assert.Equal(trackExtra.Album.Title, _track.Album);
             Assert.Equal(5, _track.AlbumPosition);
-            Assert.Equal(new[] {"Reggae", "Rock", "Jazz"}, _track.Genres);
+            Assert.Empty(_track.Genres);
             Assert.Equal(1337, _track.Length);
-            Assert.Equal("http://xlarge-cover-url.local", _track.ArtExtraLargeUrl);
-            Assert.Equal("http://large-cover-url.local", _track.ArtLargeUrl);
-            Assert.Equal("http://medium-cover-url.local", _track.ArtMediumUrl);
-            Assert.Equal("http://small-cover-url.local", _track.ArtSmallUrl);
+            Assert.Equal("http://large-cover-url.local", _track.AlbumArtUrl);
+            Assert.Equal(new[] { "Artist", "DJ" }, _track.Performers);
+        }
+        
+        [Fact]
+        internal void MapLastFMAPITrackToTrack_ReturnsExpectedDetailedTrackWithExpectedCover300()
+        {
+            var trackExtra = new LastFMTrack
+            {
+                Name = "Do not want updated Title from this api",
+                Artist = new Artist {Name = "Do not want updated Artist from this api"},
+                Album = new Album
+                {
+                    Title = "Album Title",
+                    Position = "5",
+                    Image = new List<Image>
+                    {
+                        new Image {Size = AlbumCoverSize.extralarge.ToString(), Url = "http://512x512/xlarge-cover-url.local"},
+                        new Image {Size = AlbumCoverSize.large.ToString(), Url = "http://300s/large-cover-url.local"},
+                        new Image {Size = AlbumCoverSize.medium.ToString(), Url = "http://96s/medium-cover-url.local"},
+                        new Image {Size = AlbumCoverSize.small.ToString(), Url = "http://64s/small-cover-url.local"}
+                    }
+                },
+                Toptags = new Toptags(),
+                Duration = 1337000
+            };
+
+            _lastFMAPI.MapLastFMTrackToTrack(_track, trackExtra);
+
+            Assert.Equal("http://300s/large-cover-url.local", _track.AlbumArtUrl);
         }
 
         [Fact]
@@ -172,10 +197,7 @@ namespace EspionSpotify.Tests
             Assert.Null(track.AlbumPosition);
             Assert.Equal(new string[] { }, track.Genres);
             Assert.Null(track.Length);
-            Assert.Null(track.ArtExtraLargeUrl);
-            Assert.Null(track.ArtLargeUrl);
-            Assert.Null(track.ArtMediumUrl);
-            Assert.Null(track.ArtSmallUrl);
+            Assert.Null(track.AlbumArtUrl);
         }
     }
 }

--- a/EspionSpotify.Tests/MapperID3Tests.cs
+++ b/EspionSpotify.Tests/MapperID3Tests.cs
@@ -13,8 +13,7 @@ namespace EspionSpotify.Tests
 {
     public class MapperID3Tests
     {
-        private const string ART_LINK1 = "https://raw.githubusercontent.com/jwallet/spy-spotify/master/psd/logo-en.png";
-        private const string ART_LINK2 = "https://raw.githubusercontent.com/jwallet/spy-spotify/master/psd/logo-fr.png";
+        private const string ART_LINK = "https://raw.githubusercontent.com/jwallet/spy-spotify/master/psd/logo-en.png";
         private readonly OutputFile _currentFile;
         private readonly IFileSystem _fileSystem;
         private readonly Track _track;
@@ -137,9 +136,7 @@ namespace EspionSpotify.Tests
                 Genres = new[] {"Hotel", "India", "Juliet"},
                 Disc = 1,
                 Year = 2020,
-                ArtLargeUrl = "www.google.com",
-                ArtMediumUrl = ART_LINK1,
-                ArtSmallUrl = ART_LINK2
+                AlbumArtUrl = ART_LINK,
             };
 
             var userSettings = new UserSettings {OrderNumberInMediaTagEnabled = false};
@@ -163,7 +160,7 @@ namespace EspionSpotify.Tests
             Assert.Equal((uint) track.Year, tags.Year);
 
             Assert.Single(tags.Pictures);
-            Assert.Equal(track.ArtMedium.Length, tags.Pictures[0].Data.Count);
+            Assert.Equal(track.AlbumArtImage.Length, tags.Pictures[0].Data.Count);
             Assert.Equal(PictureType.FrontCover, tags.Pictures[0].Type);
         }
     }

--- a/EspionSpotify.Tests/SpotifyAPITests.cs
+++ b/EspionSpotify.Tests/SpotifyAPITests.cs
@@ -132,10 +132,7 @@ namespace EspionSpotify.Tests
             Assert.Equal("", _track.Album);
             Assert.Equal(Array.Empty<string>(), _track.Genres);
             Assert.Null(_track.Year);
-            Assert.Null(_track.ArtExtraLargeUrl);
-            Assert.Null(_track.ArtLargeUrl);
-            Assert.Null(_track.ArtMediumUrl);
-            Assert.Null(_track.ArtSmallUrl);
+            Assert.Null(_track.AlbumArtUrl);
         }
 
         [Fact]
@@ -160,10 +157,7 @@ namespace EspionSpotify.Tests
             Assert.Equal("Album Name", _track.Album);
             Assert.Equal(new[] {"Reggae", "Rock", "Jazz"}, _track.Genres);
             Assert.Equal(2010, _track.Year);
-            Assert.Null(_track.ArtExtraLargeUrl);
-            Assert.Null(_track.ArtLargeUrl);
-            Assert.Null(_track.ArtMediumUrl);
-            Assert.Null(_track.ArtSmallUrl);
+            Assert.Null(_track.AlbumArtUrl);
         }
 
         [Fact]
@@ -192,7 +186,13 @@ namespace EspionSpotify.Tests
                         Height = 256,
                         Width = 256,
                         Url = "http://256x256.img"
-                    }
+                    },
+                    new Image
+                    {
+                    Height = 512,
+                    Width = 512,
+                    Url = "http://512x512.img"
+                },
                 }
             };
 
@@ -202,10 +202,7 @@ namespace EspionSpotify.Tests
             Assert.Equal("Album Name", _track.Album);
             Assert.Equal(new[] {"Reggae", "Rock", "Jazz"}, _track.Genres);
             Assert.Equal(2010, _track.Year);
-            Assert.Equal("http://256x256.img", _track.ArtExtraLargeUrl);
-            Assert.Equal("http://64x64.img", _track.ArtLargeUrl);
-            Assert.Null(_track.ArtMediumUrl);
-            Assert.Null(_track.ArtSmallUrl);
+            Assert.Equal("http://256x256.img", _track.AlbumArtUrl);
         }
 
         [Fact]
@@ -255,9 +252,9 @@ namespace EspionSpotify.Tests
                     },
                     new Image
                     {
-                        Height = 256,
-                        Width = 256,
-                        Url = "http://256x256.img"
+                        Height = 300,
+                        Width = 300,
+                        Url = "http://300x300.img"
                     }
                 }
             };
@@ -268,10 +265,7 @@ namespace EspionSpotify.Tests
             Assert.Equal("Album Name", _track.Album);
             Assert.Equal(new[] {"Reggae", "Rock", "Jazz"}, _track.Genres);
             Assert.Equal(2010, _track.Year);
-            Assert.Equal("http://512x512.img", _track.ArtExtraLargeUrl);
-            Assert.Equal("http://256x256.img", _track.ArtLargeUrl);
-            Assert.Equal("http://128x128.img", _track.ArtMediumUrl);
-            Assert.Equal("http://64x64.img", _track.ArtSmallUrl);
+            Assert.Equal("http://300x300.img", _track.AlbumArtUrl);
         }
     }
 }

--- a/EspionSpotify.Tests/TrackTests.cs
+++ b/EspionSpotify.Tests/TrackTests.cs
@@ -66,12 +66,12 @@ namespace EspionSpotify.Tests
             {
                 Album = "Album",
                 AlbumPosition = 1,
-                ArtExtraLargeUrl = "http://logo.png"
+                AlbumArtUrl = "http://logo.png"
             };
 
             Assert.Equal(initialTrack.ToString(), track.ToString());
             Assert.NotEqual(initialTrack.Album, track.Album);
-            Assert.NotEqual(initialTrack.ArtExtraLargeUrl, track.ArtExtraLargeUrl);
+            Assert.NotEqual(initialTrack.AlbumArtUrl, track.AlbumArtUrl);
             Assert.NotEqual(track, new Track());
         }
 

--- a/EspionSpotify/API/MapperID3.cs
+++ b/EspionSpotify/API/MapperID3.cs
@@ -70,9 +70,9 @@ namespace EspionSpotify.API
             tags.Disc = (uint) (Track.Disc ?? 0);
             tags.Year = (uint) (Track.Year ?? 0);
 
-            await FetchMediaPictures();
-
-            tags.Pictures = GetMediaPictureTag();
+            await FetchMediaPicture();
+            var albumArtCover = GetAlbumCoverToPicture(Track.AlbumArtImage);
+            tags.Pictures = albumArtCover != null ? new IPicture[] { albumArtCover } : null;
         }
 
         #region MP3 Tags updater
@@ -90,32 +90,10 @@ namespace EspionSpotify.API
 
         #endregion MP3 Tags updater
 
-        private async Task FetchMediaPictures()
+        private async Task FetchMediaPicture()
         {
-            var taskGetArtXL = GetAlbumCover(Track.ArtExtraLargeUrl);
-            var taskGetArtL = GetAlbumCover(Track.ArtLargeUrl);
-            var taskGetArtM = GetAlbumCover(Track.ArtMediumUrl);
-            var taskGetArtS = GetAlbumCover(Track.ArtSmallUrl);
-
-            await Task.WhenAll(taskGetArtXL, taskGetArtL, taskGetArtM, taskGetArtS);
-
-            Track.ArtExtraLarge = await taskGetArtXL;
-            Track.ArtLarge = await taskGetArtL;
-            Track.ArtMedium = await taskGetArtM;
-            Track.ArtSmall = await taskGetArtS;
-        }
-
-        private IPicture[] GetMediaPictureTag()
-        {
-            var pictures = new IPicture[4]
-            {
-                GetAlbumCoverToPicture(Track.ArtExtraLarge),
-                GetAlbumCoverToPicture(Track.ArtLarge),
-                GetAlbumCoverToPicture(Track.ArtMedium),
-                GetAlbumCoverToPicture(Track.ArtSmall)
-            }.Where(x => x != null).ToList();
-
-            return pictures.Any() ? new[] {pictures.First()} : null;
+            var image = await GetAlbumCover(Track.AlbumArtUrl);
+            Track.AlbumArtImage = image;
         }
 
         private int? GetTrackNumber()

--- a/EspionSpotify/API/SpotifyAPI.cs
+++ b/EspionSpotify/API/SpotifyAPI.cs
@@ -97,12 +97,12 @@ namespace EspionSpotify.API
 
             if (spotifyAlbum.Images?.Count > 0)
             {
-                var sorted = spotifyAlbum.Images.OrderByDescending(i => i.Width).ToList();
-
-                if (sorted.Count > 0) track.ArtExtraLargeUrl = sorted[0].Url;
-                if (sorted.Count > 1) track.ArtLargeUrl = sorted[1].Url;
-                if (sorted.Count > 2) track.ArtMediumUrl = sorted[2].Url;
-                if (sorted.Count > 3) track.ArtSmallUrl = sorted[3].Url;
+                track.AlbumArtUrl = spotifyAlbum.Images
+                    .OrderByDescending(i => i.Width)
+                    .Where(i => i.Width <= 300)
+                    .Select(i => i.Url)
+                    .ToArray()
+                    .FirstOrDefault();
             }
         }
 
@@ -146,6 +146,9 @@ namespace EspionSpotify.API
 
             if (_api == null) return false;
 
+            var devices = _api.GetDevices();
+            
+            
             await Task.Delay(100);
 
             var playback = await _api.GetPlaybackWithoutExceptionAsync();

--- a/EspionSpotify/API/SpotifyAPI.cs
+++ b/EspionSpotify/API/SpotifyAPI.cs
@@ -146,9 +146,6 @@ namespace EspionSpotify.API
 
             if (_api == null) return false;
 
-            var devices = _api.GetDevices();
-            
-            
             await Task.Delay(100);
 
             var playback = await _api.GetPlaybackWithoutExceptionAsync();

--- a/EspionSpotify/Extensions/StringExtensions.cs
+++ b/EspionSpotify/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -29,6 +30,13 @@ namespace EspionSpotify.Extensions
         public static ExternalAPIType? ToMediaTagsAPI(this string value)
         {
             return value.ToEnum<ExternalAPIType>(true);
+        }
+
+        public static IEnumerable<string> ToPerformers(this string value)
+        {
+            var match = new Regex(@"\((with |feat\. )(?<performers>.*)\)").Match(value);
+            var performers = match.Groups["performers"].ToString().Replace(" & ", ", ");
+            return Regex.Split(performers, @", ").AsEnumerable();
         }
 
         public static LanguageType? ToLanguageType(this string value)

--- a/EspionSpotify/Models/LastFMNode.cs
+++ b/EspionSpotify/Models/LastFMNode.cs
@@ -59,6 +59,16 @@ namespace EspionSpotify.Models
         public string LargeCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.large)?.Url;
         public string MediumCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.medium)?.Url;
         public string SmallCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.small)?.Url;
+
+        public void FromSingleAlbum(LastFMAlbum album)
+        {
+            Image = album.Image;
+            Title = album.Name;
+            Position = "1";
+            Artist = album.Artist;
+            Mbid = album.Mbid;
+            Url = album.Url;
+        }
     }
 
     [XmlRoot(ElementName = "tag")]
@@ -102,6 +112,39 @@ namespace EspionSpotify.Models
         [XmlElement(ElementName = "album")] public Album Album { get; set; }
 
         [XmlElement(ElementName = "toptags")] public Toptags Toptags { get; set; }
+        
+        [XmlElement(ElementName = "image")] public List<Image> Image { get; set; }
+    }
+
+    [XmlRoot(ElementName = "album")]
+    public class LastFMAlbum
+    {
+        [XmlElement(ElementName = "name")]
+        // album title
+        public string Name { get; set; }
+        
+        [XmlElement(ElementName = "artist")]
+        public string Artist { get; set; }
+        
+        [XmlElement(ElementName = "url")] public string Url { get; set; }
+        
+        [XmlElement(ElementName = "mbid")] public string Mbid { get; set; }
+
+        [XmlElement(ElementName = "listeners")]
+        public string Listeners { get; set; }
+
+        [XmlElement(ElementName = "playcount")]
+        public string Playcount { get; set; }
+        
+        [XmlElement(ElementName = "tags")] public List<Tag> Tags { get; set; }
+        
+        [XmlElement(ElementName = "image")] public List<Image> Image { get; set; }
+        
+        public string AlbumTitle => Name;
+        public string ExtraLargeCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.extralarge)?.Url;
+        public string LargeCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.large)?.Url;
+        public string MediumCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.medium)?.Url;
+        public string SmallCoverUrl => Image.FirstOrDefault(x => x?.CoverSize == AlbumCoverSize.small)?.Url;
     }
 
     [XmlRoot(ElementName = "error")]
@@ -120,6 +163,8 @@ namespace EspionSpotify.Models
         public string StatusMessage { get; set; }
 
         [XmlElement(ElementName = "track")] public LastFMTrack Track { get; set; }
+        
+        [XmlElement(ElementName = "album")] public LastFMAlbum Album { get; set; }
 
         [XmlElement(ElementName = "error")] public Error Error { get; set; }
 

--- a/EspionSpotify/Models/Track.cs
+++ b/EspionSpotify/Models/Track.cs
@@ -39,15 +39,8 @@ namespace EspionSpotify.Models
             AlbumArtists = track.AlbumArtists;
             Year = track.Year;
 
-            ArtExtraLargeUrl = track.ArtExtraLargeUrl;
-            ArtLargeUrl = track.ArtLargeUrl;
-            ArtMediumUrl = track.ArtMediumUrl;
-            ArtSmallUrl = track.ArtSmallUrl;
-
-            ArtExtraLarge = track.ArtExtraLarge;
-            ArtLarge = track.ArtLarge;
-            ArtMedium = track.ArtMedium;
-            ArtSmall = track.ArtSmall;
+            AlbumArtUrl = track.AlbumArtUrl;
+            AlbumArtImage = track.AlbumArtImage;
         }
 
         public string Artists
@@ -96,15 +89,9 @@ namespace EspionSpotify.Models
         public string[] AlbumArtists { get; set; }
         public int? Year { get; set; }
 
-        public string ArtExtraLargeUrl { get; set; }
-        public string ArtLargeUrl { get; set; }
-        public string ArtMediumUrl { get; set; }
-        public string ArtSmallUrl { get; set; }
-
-        public byte[] ArtExtraLarge { get; set; }
-        public byte[] ArtLarge { get; set; }
-        public byte[] ArtMedium { get; set; }
-        public byte[] ArtSmall { get; set; }
+        public string AlbumArtUrl { get; set; }
+        
+        public byte[] AlbumArtImage { get; set; }
 
         private bool IsNormal =>
             !string.IsNullOrEmpty(Artist)

--- a/EspionSpotify/Translations/en.Designer.cs
+++ b/EspionSpotify/Translations/en.Designer.cs
@@ -628,7 +628,7 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lost connection to Spotify API. Make sure you authorized Spytify on the same Spotify account that is currently connected to Spotify-Desktop app to be able to get metadata of the current track. Also, double check your Spotify Client_ID and Client_Secret entered. In the meantime Spytify will use LastFM API..
+        ///   Looks up a localized string similar to Lost connection to Spotify API. Make sure you authorized Spytify on the same Spotify account that is currently connected to Spotify-Desktop app to be able to get metadata of the current track. Also, make sure the current active device on Spotify is your PC and double check the Spotify Client_ID and Client_Secret you entered in Spytify. In the meantime Spytify will use LastFM API..
         /// </summary>
         internal static string msgBodyFailedToUseSpotifyAPI {
             get {

--- a/EspionSpotify/Translations/en.resx
+++ b/EspionSpotify/Translations/en.resx
@@ -390,7 +390,7 @@
     <comment>interface</comment>
   </data>
   <data name="msgBodyFailedToUseSpotifyAPI" xml:space="preserve">
-    <value>Lost connection to Spotify API. Make sure you authorized Spytify on the same Spotify account that is currently connected to Spotify-Desktop app to be able to get metadata of the current track. Also, double check your Spotify Client_ID and Client_Secret entered. In the meantime Spytify will use LastFM API.</value>
+    <value>Lost connection to Spotify API. Make sure you authorized Spytify on the same Spotify account that is currently connected to Spotify-Desktop app to be able to get metadata of the current track. Also, make sure the current active device on Spotify is your PC and double check the Spotify Client_ID and Client_Secret you entered in Spytify. In the meantime Spytify will use LastFM API.</value>
     <comment>message</comment>
   </data>
   <data name="msgTitleFailedToUseSpotifyAPI" xml:space="preserve">

--- a/EspionSpotify/Translations/fr.Designer.cs
+++ b/EspionSpotify/Translations/fr.Designer.cs
@@ -628,7 +628,7 @@ namespace EspionSpotify.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connexion perdue avec Spotify API. Soyez certain d&apos;autoriser Spytify sur le même compte Spotify présentement connecté à Spotify-Desktop pour être capable de récupérer les métadonnées de la piste courante. Aussi, revalidez le Client_ID et Client_Secret saisis. Entre temps Spytify utilisera LastFM API..
+        ///   Looks up a localized string similar to Connexion perdue avec Spotify API. Soyez certain d&apos;autoriser Spytify sur le même compte Spotify présentement connecté à Spotify-Desktop pour être capable de récupérer les métadonnées de la piste courante. Aussi, validez que l&apos;appareil actif en ce moment est bien votre PC et revalidez les Client_ID et Client_Secret saisis dans Spytify. Entre temps Spytify utilisera LastFM API..
         /// </summary>
         internal static string msgBodyFailedToUseSpotifyAPI {
             get {

--- a/EspionSpotify/Translations/fr.resx
+++ b/EspionSpotify/Translations/fr.resx
@@ -390,7 +390,7 @@
     <comment>interface</comment>
   </data>
   <data name="msgBodyFailedToUseSpotifyAPI" xml:space="preserve">
-    <value>Connexion perdue avec Spotify API. Soyez certain d'autoriser Spytify sur le même compte Spotify présentement connecté à Spotify-Desktop pour être capable de récupérer les métadonnées de la piste courante. Aussi, revalidez le Client_ID et Client_Secret saisis. Entre temps Spytify utilisera LastFM API.</value>
+    <value>Connexion perdue avec Spotify API. Soyez certain d'autoriser Spytify sur le même compte Spotify présentement connecté à Spotify-Desktop pour être capable de récupérer les métadonnées de la piste courante. Aussi, validez que l'appareil actif en ce moment est bien votre PC et revalidez les Client_ID et Client_Secret saisis dans Spytify. Entre temps Spytify utilisera LastFM API.</value>
     <comment>message</comment>
   </data>
   <data name="msgTitleFailedToUseSpotifyAPI" xml:space="preserve">

--- a/EspionSpotify/Watcher.cs
+++ b/EspionSpotify/Watcher.cs
@@ -98,7 +98,7 @@ namespace EspionSpotify
             var isAudioSessionNotFound = !await SetSpotifyAudioSessionAndWaitToStart();
             BindSpotifyEventHandlers();
             Ready = false;
-
+            
             if (Recorder.TestFileWriter(_form, _audioSession, _userSettings))
             {
                 if (isAudioSessionNotFound)


### PR DESCRIPTION
close #357 
close #464 

#### LastFM
- if no album cover is returned the first time or the album is related to "Various Artists" (we don't want compilation cover or top summer hits 2004), we then try to find a single album titled with the track name.
- lastfm will now set contributing artists based on the names found between the parenthesis in the track title `Artist - Title (with DJ)`

#### Both API
- will try to use the album cover of 300x300px or lower, since mp3 standard is still 300px for covers.