### PR TITLE
Add url/uri to mp3 comments (for post-processing / debugging)

### DIFF
--- a/EspionSpotify/API/LastFMAPI.cs
+++ b/EspionSpotify/API/LastFMAPI.cs
@@ -50,6 +50,7 @@ namespace EspionSpotify.API
             track.AlbumPosition = trackExtra.Album?.TrackPosition;
             track.Length = trackExtra.Duration.HasValue ? trackExtra.Duration / 1000 : null;
             track.Genres = new string[] { };
+            track.Comment = trackExtra.Url;
             
             var extraLarge = trackExtra.Album?.ExtraLargeCoverUrl;
             var artLargeUrl = trackExtra.Album?.LargeCoverUrl;

--- a/EspionSpotify/API/MapperID3.cs
+++ b/EspionSpotify/API/MapperID3.cs
@@ -69,6 +69,8 @@ namespace EspionSpotify.API
 
             tags.Disc = (uint) (Track.Disc ?? 0);
             tags.Year = (uint) (Track.Year ?? 0);
+            
+            tags.Comment = Track.Comment;
 
             await FetchMediaPicture();
             var albumArtCover = GetAlbumCoverToPicture(Track.AlbumArtImage);

--- a/EspionSpotify/API/SpotifyAPI.cs
+++ b/EspionSpotify/API/SpotifyAPI.cs
@@ -85,6 +85,7 @@ namespace EspionSpotify.API
             track.AlbumPosition = spotifyTrack.TrackNumber;
             track.Performers = performers;
             track.Disc = spotifyTrack.DiscNumber;
+            track.Comment = spotifyTrack.Uri;
         }
 
         public void MapSpotifyAlbumToTrack(Track track, FullAlbum spotifyAlbum)

--- a/EspionSpotify/Models/Track.cs
+++ b/EspionSpotify/Models/Track.cs
@@ -41,6 +41,7 @@ namespace EspionSpotify.Models
 
             AlbumArtUrl = track.AlbumArtUrl;
             AlbumArtImage = track.AlbumArtImage;
+            Comment = track.Comment;
         }
 
         public string Artists
@@ -92,6 +93,8 @@ namespace EspionSpotify.Models
         public string AlbumArtUrl { get; set; }
         
         public byte[] AlbumArtImage { get; set; }
+        
+        public string Comment { get; set; }
 
         private bool IsNormal =>
             !string.IsNullOrEmpty(Artist)


### PR DESCRIPTION
This adds the Spotify uri / LastFM url to the comment tag of the saved file, to make debugging and post-processing (like in my case specifically: adding lyrics with a python script) easier.

ps.: I couldn't yet figure out how to add an option switch (as I'm new to c#), but I'm working on it