### PR TITLE
Check node for null in LastFMAPI

### DIFF
--- a/EspionSpotify/API/LastFMAPI.cs
+++ b/EspionSpotify/API/LastFMAPI.cs
@@ -34,7 +34,7 @@ namespace EspionSpotify.API
 
         public async Task<bool> UpdateTrack(Track track)
         {
-            return await UpdateTrack(track, null);
+           return await UpdateTrack(track, null);
         }
 
         public void Reset()
@@ -142,7 +142,7 @@ namespace EspionSpotify.API
             var url = GetTrackInfo(encodedArtist, encodedTitle);
             var node = await FetchFromAPI(url);
 
-           if (node.Track == null) return false;
+            if (node?.Track == null) return false;
 
             var trackExtra = node.Track;
 
@@ -173,7 +173,7 @@ namespace EspionSpotify.API
             var url = GetAlbumInfo(encodedArtist, encodedTitle);
             var node = await FetchFromAPI(url);
             
-            if (node.Album == null) return;
+            if (node?.Album == null) return;
 
             trackExtra.Album ??= new Album();
             trackExtra.Album.FromSingleAlbum(node.Album);


### PR DESCRIPTION
 In case of an exception (see #508) it was returning `null` which lead to some NREs later (and nothing being recorded)